### PR TITLE
Set-up code scanning with CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,43 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    container:
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'python' ]
+        sdk: [ '$NANOS_SDK', '$NANOX_SDK', '$NANOSP_SDK' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        queries: security-and-quality
+        
+    # CodeQL will create the database during the compilation
+    - name: Build
+      run: |
+        cd workdir/app-near/
+        make BOLOS_SDK=${{ matrix.sdk }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/workdir/app-near/src/base58.c
+++ b/workdir/app-near/src/base58.c
@@ -1,0 +1,155 @@
+/*****************************************************************************
+ *   (c) 2020 Ledger SAS.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *****************************************************************************/
+
+#include <stddef.h>   // size_t
+#include <stdint.h>   // uint*_t
+#include <string.h>   // memmove, memset
+#include <stdbool.h>  // bool
+
+#include "base58.h"
+
+uint8_t const BASE58_TABLE[] = {
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  //
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  //
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  //
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  //
+    0xFF, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0xFF, 0xFF,  //
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,  //
+    0x10, 0xFF, 0x11, 0x12, 0x13, 0x14, 0x15, 0xFF, 0x16, 0x17, 0x18, 0x19,  //
+    0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  //
+    0xFF, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B,  //
+    0xFF, 0x2C, 0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36,  //
+    0x37, 0x38, 0x39, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF                           //
+};
+
+char const BASE58_ALPHABET[] = {
+    '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',  //
+    'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W',  //
+    'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'm',  //
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'             //
+};
+
+int base58_decode(const char *in, size_t in_len, uint8_t *out, size_t out_len) {
+    uint8_t tmp[MAX_DEC_INPUT_SIZE] = {0};
+    uint8_t buffer[MAX_DEC_INPUT_SIZE] = {0};
+    uint8_t j;
+    uint8_t start_at;
+    uint8_t zero_count = 0;
+
+    if (in_len > MAX_DEC_INPUT_SIZE || in_len < 2) {
+        return -1;
+    }
+
+    memmove(tmp, in, in_len);
+
+    for (uint8_t i = 0; i < in_len; i++) {
+        if (in[i] >= sizeof(BASE58_TABLE)) {
+            return -1;
+        }
+
+        tmp[i] = BASE58_TABLE[(int) in[i]];
+
+        if (tmp[i] == 0xFF) {
+            return -1;
+        }
+    }
+
+    while ((zero_count < in_len) && (tmp[zero_count] == 0)) {
+        ++zero_count;
+    }
+
+    j = in_len;
+    start_at = zero_count;
+    while (start_at < in_len) {
+        uint16_t remainder = 0;
+        for (uint8_t div_loop = start_at; div_loop < in_len; div_loop++) {
+            uint16_t digit256 = (uint16_t)(tmp[div_loop] & 0xFF);
+            uint16_t tmp_div = remainder * 58 + digit256;
+            tmp[div_loop] = (uint8_t)(tmp_div / 256);
+            remainder = tmp_div % 256;
+        }
+
+        if (tmp[start_at] == 0) {
+            ++start_at;
+        }
+
+        buffer[--j] = (uint8_t) remainder;
+    }
+
+    while ((j < in_len) && (buffer[j] == 0)) {
+        ++j;
+    }
+
+    int length = in_len - (j - zero_count);
+
+    if ((int) out_len < length) {
+        return -1;
+    }
+
+    memmove(out, buffer + j - zero_count, length);
+
+    return length;
+}
+
+int base58_encode(const uint8_t *in, size_t in_len, char *out, size_t out_len) {
+    uint8_t buffer[MAX_ENC_INPUT_SIZE * 138 / 100 + 1] = {0};
+    size_t i, j;
+    size_t stop_at;
+    size_t zero_count = 0;
+    size_t output_size;
+
+    if (in_len > MAX_ENC_INPUT_SIZE) {
+        return -1;
+    }
+
+    while ((zero_count < in_len) && (in[zero_count] == 0)) {
+        ++zero_count;
+    }
+
+    output_size = (in_len - zero_count) * 138 / 100 + 1;
+    stop_at = output_size - 1;
+    for (size_t start_at = zero_count; start_at < in_len; start_at++) {
+        int carry = in[start_at];
+        for (j = output_size - 1; (int) j >= 0; j--) {
+            carry += 256 * buffer[j];
+            buffer[j] = carry % 58;
+            carry /= 58;
+
+            if (j <= stop_at - 1 && carry == 0) {
+                break;
+            }
+        }
+        stop_at = j;
+    }
+
+    j = 0;
+    while (j < output_size && buffer[j] == 0) {
+        j += 1;
+    }
+
+    if (out_len < zero_count + output_size - j) {
+        return -1;
+    }
+
+    memset(out, BASE58_ALPHABET[0], zero_count);
+
+    i = zero_count;
+    while (j < output_size) {
+        out[i++] = BASE58_ALPHABET[buffer[j++]];
+    }
+
+    return i;
+}

--- a/workdir/app-near/src/base58.h
+++ b/workdir/app-near/src/base58.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <stddef.h>   // size_t
+#include <stdint.h>   // uint*_t
+#include <stdbool.h>  // bool
+
+/**
+ * Maximum length of input when decoding in base 58.
+ */
+#define MAX_DEC_INPUT_SIZE 164
+/**
+ * Maximum length of input when encoding in base 58.
+ */
+#define MAX_ENC_INPUT_SIZE 120
+
+/**
+ * Decode input string in base 58.
+ *
+ * @see https://tools.ietf.org/html/draft-msporny-base58-02
+ *
+ * @param[in]  in
+ *   Pointer to input string buffer.
+ * @param[in]  in_len
+ *   Length of the input string buffer.
+ * @param[out] out
+ *   Pointer to output byte buffer.
+ * @param[in]  out_len
+ *   Maximum length to write in output byte buffer.
+ *
+ * @return number of bytes decoded, -1 otherwise.
+ *
+ */
+int base58_decode(const char *in, size_t in_len, uint8_t *out, size_t out_len);
+
+/**
+ * Encode input bytes in base 58.
+ *
+ * @see https://tools.ietf.org/html/draft-msporny-base58-02
+ *
+ * @param[in]  in
+ *   Pointer to input byte buffer.
+ * @param[in]  in_len
+ *   Length of the input byte buffer.
+ * @param[out] out
+ *   Pointer to output string buffer.
+ * @param[in]  out_len
+ *   Maximum length to write in output byte buffer.
+ *
+ * @return number of bytes encoded, -1 otherwise.
+ *
+ */
+int base58_encode(const uint8_t *in, size_t in_len, char *out, size_t out_len);

--- a/workdir/app-near/src/context.h
+++ b/workdir/app-near/src/context.h
@@ -28,7 +28,7 @@ typedef struct signingContext_t {
 
 // A place to store data during the confirming the address
 typedef struct addressesContext_t {
-	char public_key[32];
+	uint8_t public_key[32];
 } addressesContext_t;
 
 typedef union {

--- a/workdir/app-near/src/get_public_key.c
+++ b/workdir/app-near/src/get_public_key.c
@@ -1,6 +1,7 @@
 #include "get_public_key.h"
 #include "os.h"
 #include "ux.h"
+#include "base58.h"
 #include "utils.h"
 #include "main.h"
 
@@ -68,9 +69,10 @@ void handle_get_public_key(uint8_t p1, uint8_t p2, const uint8_t *input_buffer, 
     const char prefix[] = "ed25519:";
     memset(address, 0, sizeof(address));
     snprintf(address, sizeof(address), prefix);
-    encode_base58(
-        tmp_ctx.address_context.public_key, sizeof(tmp_ctx.address_context.public_key),
-        address + sizeof(prefix) - 1, sizeof(address) - sizeof(prefix) + 1);
+    if (base58_encode(tmp_ctx.address_context.public_key, sizeof(tmp_ctx.address_context.public_key),
+        address + sizeof(prefix) - 1, sizeof(address) - sizeof(prefix) + 1) < 0) {
+            THROW(INVALID_PARAMETER);
+    }
 
     if (p1 == RETURN_ONLY) {
         send_response(set_result_get_public_key(), true);

--- a/workdir/app-near/src/get_public_key.c
+++ b/workdir/app-near/src/get_public_key.c
@@ -5,6 +5,9 @@
 #include "utils.h"
 #include "main.h"
 
+#define ADDRESS_PREFIX "ed25519:"
+#define ADDRESS_PREFIX_SIZE strlen(ADDRESS_PREFIX)
+
 static char address[FULL_ADDRESS_LENGTH];
 
 static uint32_t set_result_get_public_key() {
@@ -66,11 +69,10 @@ void handle_get_public_key(uint8_t p1, uint8_t p2, const uint8_t *input_buffer, 
 
     memcpy(tmp_ctx.address_context.public_key, public_key.W, 32);
 
-    const char prefix[] = "ed25519:";
     memset(address, 0, sizeof(address));
-    snprintf(address, sizeof(address), prefix);
+    strcpy(address, ADDRESS_PREFIX);
     if (base58_encode(tmp_ctx.address_context.public_key, sizeof(tmp_ctx.address_context.public_key),
-        address + sizeof(prefix) - 1, sizeof(address) - sizeof(prefix) + 1) < 0) {
+        address + ADDRESS_PREFIX_SIZE, sizeof(address) - ADDRESS_PREFIX_SIZE - 1) < 0) {
             THROW(INVALID_PARAMETER);
     }
 

--- a/workdir/app-near/src/get_wallet_id.c
+++ b/workdir/app-near/src/get_wallet_id.c
@@ -66,7 +66,7 @@ void handle_get_wallet_id(uint8_t p1, uint8_t p2, const uint8_t *input_buffer, u
 
     memcpy(tmp_ctx.address_context.public_key, public_key.W, 32);
 
-    snprintf(&wallet_id, sizeof(wallet_id), "%.*H", 32, public_key.W);
+    bin_to_hex(wallet_id, public_key.W, 32);
 
     ux_flow_init(0, ux_display_wallet_id_flow, NULL);
     *flags |= IO_ASYNCH_REPLY;

--- a/workdir/app-near/src/utils.c
+++ b/workdir/app-near/src/utils.c
@@ -5,7 +5,16 @@
 #include "utils.h"
 #include "menu.h"
 
-#define ACCOUNT_ADDRESS_PREFIX 1
+void bin_to_hex(char *out, const uint8_t *in, size_t len) {
+    const unsigned char hex_digits[] = {'0', '1', '2', '3', '4', '5', '6', '7',
+                                        '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+
+    while (len--) {
+        *out++ = hex_digits[(*in >> 4) & 0xF];
+        *out++ = hex_digits[(*in++) & 0xF];
+    }
+    *out = 0;
+}
 
 void send_response(uint8_t tx, bool approve) {
     G_io_apdu_buffer[tx++] = approve? 0x90 : 0x69;

--- a/workdir/app-near/src/utils.c
+++ b/workdir/app-near/src/utils.c
@@ -7,56 +7,6 @@
 
 #define ACCOUNT_ADDRESS_PREFIX 1
 
-static const char BASE_58_ALPHABET[] = {'1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
-                                        'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q',
-                                        'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g',
-                                        'h', 'i', 'j', 'k', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-                                        'w', 'x', 'y', 'z'};
-
-unsigned char encode_base58(char WIDE *in, unsigned char length,
-                           char *out, unsigned char maxoutlen) {
-    unsigned char tmp[164];
-    unsigned char buffer[164];
-    unsigned char j;
-    unsigned char startAt;
-    unsigned char zeroCount = 0;
-    if (length > sizeof(tmp)) {
-        THROW(INVALID_PARAMETER);
-    }
-    memcpy(tmp, in, length);
-    while ((zeroCount < length) && (tmp[zeroCount] == 0)) {
-        ++zeroCount;
-    }
-    j = 2 * length;
-    startAt = zeroCount;
-    while (startAt < length) {
-        unsigned short remainder = 0;
-        unsigned char divLoop;
-        for (divLoop = startAt; divLoop < length; divLoop++) {
-            unsigned short digit256 = (unsigned short)(tmp[divLoop] & 0xff);
-            unsigned short tmpDiv = remainder * 256 + digit256;
-            tmp[divLoop] = (unsigned char)(tmpDiv / 58);
-            remainder = (tmpDiv % 58);
-        }
-        if (tmp[startAt] == 0) {
-            ++startAt;
-        }
-        buffer[--j] = (unsigned char)BASE_58_ALPHABET[remainder];
-    }
-    while ((j < (2 * length)) && (buffer[j] == BASE_58_ALPHABET[0])) {
-        ++j;
-    }
-    while (zeroCount-- > 0) {
-        buffer[--j] = BASE_58_ALPHABET[0];
-    }
-    length = 2 * length - j;
-    if (maxoutlen < length) {
-        THROW(EXCEPTION_OVERFLOW);
-    }
-    memcpy(out, (buffer + j), length);
-    return length;
-}
-
 void send_response(uint8_t tx, bool approve) {
     G_io_apdu_buffer[tx++] = approve? 0x90 : 0x69;
     G_io_apdu_buffer[tx++] = approve? 0x00 : 0x85;

--- a/workdir/app-near/src/utils.h
+++ b/workdir/app-near/src/utils.h
@@ -14,6 +14,7 @@ typedef enum rlpTxType {
     TX_FEE
 } rlpTxType;
 
+void bin_to_hex(char *out, const uint8_t *in, size_t len);
 void send_response(uint8_t tx, bool approve);
 
     // type            userid    x    y   w    h  str rad fill      fg        bg      fid iid  txt   touchparams...       ]

--- a/workdir/app-near/src/utils.h
+++ b/workdir/app-near/src/utils.h
@@ -14,9 +14,6 @@ typedef enum rlpTxType {
     TX_FEE
 } rlpTxType;
 
-unsigned char encode_base58(char WIDE *in, unsigned char length,
-                           char *out, unsigned char maxoutlen);
-
 void send_response(uint8_t tx, bool approve);
 
     // type            userid    x    y   w    h  str rad fill      fg        bg      fid iid  txt   touchparams...       ]


### PR DESCRIPTION
This PR adds code scanning with CodeQL. It also:

- Fixes compilation warnings by not calling `snprintf` with our custom formatter. This allows using stricter `-Wformat-xxx` compilation options.
- Replaces the custom base58 implementation (or was it the one from the old Boilerplate app?) with the implementation from the new Boilerplate app. It has a better prototype and does not throw exceptions.

Note: Imo the base58 functions should be part of the SDK...