### PR TITLE
Remove reference to deprecated "ux" variable

### DIFF
--- a/workdir/app-near/src/globals.h
+++ b/workdir/app-near/src/globals.h
@@ -11,7 +11,6 @@
 #define FULL_ADDRESS_LENGTH 60
 #define BIP32_PATH 5
 
-extern ux_state_t ux;
 // display stepped screens
 extern unsigned int ux_step;
 extern unsigned int ux_step_count;

--- a/workdir/app-near/src/ui/ui.h
+++ b/workdir/app-near/src/ui/ui.h
@@ -29,8 +29,6 @@
 #include "../crypto/ledger_crypto.h"
 #include "os_io_seproxyhal.h"
 
-extern ux_state_t ux;
-
 enum UI_STATE { UI_IDLE, UI_VERIFY };
 extern enum UI_STATE ui_state;
 


### PR DESCRIPTION
`ux` variable from older SDK was referenced twice in the app:

```c
ux_state_t ux;
```

This variable is not used, these lines can be safely deleted. That prevents CodeQL to emit 2 "Notes" due to the presence of a global variable with a short name.