### PR TITLE
src: Update glyphs.h includes so that they don't use relatives includes

### DIFF
--- a/workdir/app-near/src/ui/ui.c
+++ b/workdir/app-near/src/ui/ui.c
@@ -20,7 +20,7 @@
 
 #include "ui.h"
 #include <stdbool.h>
-#include "../glyphs.h"
+#include "glyphs.h"
 #include "../main.h"
 #include "../globals.h"
 #include "../sign_transaction.h"


### PR DESCRIPTION
This is necessary as this file is automatically generated and it's generation location is going to change