### PR TITLE
fix: not appending to buffer on multiple ops

### DIFF
--- a/workdir/app-near/src/sign_transaction.c
+++ b/workdir/app-near/src/sign_transaction.c
@@ -360,6 +360,7 @@ static void add_chunk_data(const uint8_t *input_data, size_t input_length)
         // PRINTF("data_size: %d\n", input_length);
         if (tmp_ctx.signing_context.buffer_used + input_length > MAX_DATA_SIZE)
         {
+            tmp_ctx.signing_context.buffer_used = 0;
             THROW(SW_BUFFER_OVERFLOW);
         }
         memcpy(&tmp_ctx.signing_context.buffer[tmp_ctx.signing_context.buffer_used], input_data, input_length);

--- a/workdir/app-near/src/utils.c
+++ b/workdir/app-near/src/utils.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include "utils.h"
 #include "menu.h"
+#include "context.h"
 
 void bin_to_hex(char *out, const uint8_t *in, size_t len) {
     const unsigned char hex_digits[] = {'0', '1', '2', '3', '4', '5', '6', '7',
@@ -17,11 +18,14 @@ void bin_to_hex(char *out, const uint8_t *in, size_t len) {
 }
 
 void send_response(uint8_t tx, bool approve) {
+    PRINTF("send_response: tmp_ctx.signing_context.buffer_used: %d\n", tmp_ctx.signing_context.buffer_used);
     G_io_apdu_buffer[tx++] = approve? 0x90 : 0x69;
     G_io_apdu_buffer[tx++] = approve? 0x00 : 0x85;
     // Send back the response, do not restart the event loop
+    PRINTF("apdu out: %.*h\n", tx, G_io_apdu_buffer);
     io_exchange(CHANNEL_APDU | IO_RETURN_AFTER_TX, tx);
 
+    tmp_ctx.signing_context.buffer_used = 0;
     #ifdef HAVE_BAGL
     // Display back the original UX
     ui_idle();


### PR DESCRIPTION
This affects the behaviour when signing multiple tx-s WITHOUT quitting near app between operations:
Below are signatures of the very same message:
- ledger prior to fix
  - first after entering app: `8f38d3db42410b03a63110f58a0c84eaf39a22dbe4e9ca866b406347342e897fa181fd0f9dbfcd0b1d4bbec1369f0f30bce3fa393a034670c8ad2c2cee24af02`
  - second after enter: `71a89d556194d61d49691dfdc0f3921dcdf2039c0995999b8502e43b96ea830dc00d6f53870dfc0d0d382f9a9d3908f4b8525cedc9e05408a37bff009b42fa0d`
  -  third after enter: throws error `SW_BUFFER_OVERFLOW 0x6990`
    
- ledger after fix
  -  first after entering app: `8f38d3db42410b03a63110f58a0c84eaf39a22dbe4e9ca866b406347342e897fa181fd0f9dbfcd0b1d4bbec1369f0f30bce3fa393a034670c8ad2c2cee24af02`
  -  second after enter: `8f38d3db42410b03a63110f58a0c84eaf39a22dbe4e9ca866b406347342e897fa181fd0f9dbfcd0b1d4bbec1369f0f30bce3fa393a034670c8ad2c2cee24af02`
  -  third after enter: `8f38d3db42410b03a63110f58a0c84eaf39a22dbe4e9ca866b406347342e897fa181fd0f9dbfcd0b1d4bbec1369f0f30bce3fa393a034670c8ad2c2cee24af02`
